### PR TITLE
Add taxonomy info to coverage profile

### DIFF
--- a/src/slimm.hpp
+++ b/src/slimm.hpp
@@ -206,7 +206,7 @@ inline void slimm::analyze_alignments(BamFileIn & bam_file)
             append(read_name, ".1");
         else if(hasFlagLast(record))
             append(read_name, ".2");
-        
+
         // if there is no read with read_name this will create one.
         reads[read_name].add_target(record.rID, relative_bin_no);
         ++hits_count;
@@ -391,7 +391,7 @@ inline void slimm::filter_alignments()
     }
 }
 
-// get taxonomic profiles from the sam/bam 
+// get taxonomic profiles from the sam/bam
 inline void slimm::get_profiles()
 {
     Timer<>  stop_watch;
@@ -409,7 +409,7 @@ inline void slimm::get_profiles()
         avg_read_length = get_avg_read_length(bam_file, 100000);
 
         //if bin_width is not given use avg read length
-        if (options.bin_width == 0) 
+        if (options.bin_width == 0)
             options.bin_width = avg_read_length;
 
         //reset the bam_file to the first recored by closing and reopening
@@ -772,7 +772,7 @@ inline void slimm::write_abundance()
 
     std::unordered_map <uint32_t, float>    sum_abundunce_by_parent;
     std::unordered_map <uint32_t, uint32_t> sum_reads_count_by_parent;
-    
+
     for (auto t_id : taxon_id__read_count)
     {
         if (std::get<0>(db.taxid__name[t_id.first]) == rank)
@@ -845,34 +845,39 @@ inline void slimm::write_abundance()
 
 inline void slimm::write_coverage()
 {
-    std::string coverge_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_coverge");
-    std::string uniq_coverge_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_uniq_coverge");
-    std::string uniq_coverge2_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_uniq_coverge2");
+    std::string coverage_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_coverage");
+    std::string uniq_coverage_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_uniq_coverage");
+    std::string uniq_coverage2_csv_path = get_tsv_file_name(options.output_prefix, current_bam_file_path(), "_uniq_coverage2");
 
-    std::ofstream coverge_stream(coverge_csv_path);
-    std::ofstream uniq_coverge_stream(uniq_coverge_csv_path);
-    std::ofstream uniq_coverge2_stream(uniq_coverge2_csv_path);
+    std::ofstream coverage_stream(coverage_csv_path);
+    std::ofstream uniq_coverage_stream(uniq_coverage_csv_path);
+    std::ofstream uniq_coverage2_stream(uniq_coverage2_csv_path);
 
 
     for (auto valid_id : valid_ref_ids)
     {
         reference_contig current_ref = references[valid_id];
-        coverge_stream  << current_ref.accession;
-        uniq_coverge_stream  << current_ref.accession;
-        uniq_coverge2_stream  << current_ref.accession;
+        coverage_stream << current_ref.accession;
+        uniq_coverage_stream << current_ref.accession;
+        uniq_coverage2_stream << current_ref.accession;
+        for (uint32_t ti : db.ac__taxid[current_ref.accession]) {
+            coverage_stream << "," << std::get<1>(db.taxid__name[ti]);
+            uniq_coverage_stream << "," << std::get<1>(db.taxid__name[ti]);
+            uniq_coverage2_stream << "," << std::get<1>(db.taxid__name[ti]);
+        }
         for (uint32_t b=0; b < current_ref.cov.number_of_bins; ++b)
         {
-            coverge_stream  << "," << current_ref.cov.bins_height[b];
-            uniq_coverge_stream  << "," << current_ref.uniq_cov.bins_height[b];
-            uniq_coverge2_stream  << "," << current_ref.uniq_cov2.bins_height[b];
+            coverage_stream  << "," << current_ref.cov.bins_height[b];
+            uniq_coverage_stream  << "," << current_ref.uniq_cov.bins_height[b];
+            uniq_coverage2_stream  << "," << current_ref.uniq_cov2.bins_height[b];
         }
-        coverge_stream  << "\n" ;
-        uniq_coverge_stream  << "\n";
-        uniq_coverge2_stream  << "\n";
+        coverage_stream  << "\n" ;
+        uniq_coverage_stream  << "\n";
+        uniq_coverage2_stream  << "\n";
     }
-    coverge_stream.close();
-    uniq_coverge_stream.close();
-    uniq_coverge2_stream.close();
+    coverage_stream.close();
+    uniq_coverage_stream.close();
+    uniq_coverage2_stream.close();
 }
 
 inline void slimm::write_raw_stat()
@@ -890,12 +895,12 @@ inline void slimm::write_raw_stat()
                       "genome_length\t"
                       "uniq1_reads_count\t"
                       "uniq2_reads_count\t"
-  
+
                       "bins_count\t"
                       "bins_count(>0)\t"
                       "uniq1_bins_count(>0)\t"
                       "uniq2_bins_count(>0)\t"
-  
+
                       "coverage_depth\t"
                       "uniq1_coverage_depth\t"
                       "uniq2_coverage_depth\t"
@@ -919,17 +924,17 @@ inline void slimm::write_raw_stat()
                           << current_ref.length << "\t"
                           << current_ref.uniq_reads_count << "\t"
                           << current_ref.uniq_reads_count2 << "\t"
-  
+
                           << current_ref.cov.number_of_bins << "\t"
                           << current_ref.cov.none_zero_bin_count() << "\t"
                           << current_ref.uniq_cov.none_zero_bin_count() << "\t"
                           << current_ref.uniq_cov2.none_zero_bin_count() << "\t"
 
                           << current_ref.cov_depth() << "\t"
-  
+
                           << current_ref.uniq_cov_depth() << "\t"
                           << current_ref.uniq_cov_depth2() << "\t"
-  
+
                           << current_ref.cov_percent() << "\t"
                           << current_ref.uniq_cov_percent() << "\t"
                           << current_ref.uniq_cov_percent2() << "\n";


### PR DESCRIPTION
This is a small suggested change to add the taxonomy to the coverage profiles generated with the `--co` option. It will now include the taxonomy from the strain to kingdom level which makes it easier to relate the coverage profiles to the abundances reported by SLIMM. Also fixed the spelling a bit.